### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cloud/client.go
+++ b/cloud/client.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -133,7 +132,7 @@ func (it *internalClient) does(method string, request *Request) *Response {
 	if request.Stream != nil {
 		io.Copy(request.Stream, httpResponse.Body)
 	} else {
-		response.Body, response.Err = ioutil.ReadAll(httpResponse.Body)
+		response.Body, response.Err = io.ReadAll(httpResponse.Body)
 	}
 	if common.DebugFlag {
 		body := "ignore"

--- a/cmd/rcc/main.go
+++ b/cmd/rcc/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -85,7 +84,7 @@ func markTempForRecycling() {
 	target := common.RobocorpTempName()
 	if pathlib.Exists(target) {
 		filename := filepath.Join(target, "recycle.now")
-		ioutil.WriteFile(filename, []byte("True"), 0o644)
+		os.WriteFile(filename, []byte("True"), 0o644)
 		common.Debug("Marked %q for recycling.", target)
 		markedAlready = true
 	}

--- a/conda/activate.go
+++ b/conda/activate.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -62,7 +62,7 @@ func createScript(targetFolder string) (string, error) {
 	script.Execute(buffer, details)
 
 	scriptfile := filepath.Join(targetFolder, fmt.Sprintf("rcc_activate%s", commandSuffix))
-	err = ioutil.WriteFile(scriptfile, buffer.Bytes(), 0o755)
+	err = os.WriteFile(scriptfile, buffer.Bytes(), 0o755)
 	if err != nil {
 		return "", err
 	}
@@ -138,7 +138,7 @@ func Activate(sink io.Writer, targetFolder string) error {
 		return err
 	}
 	targetJson := filepath.Join(targetFolder, activateFile)
-	err = ioutil.WriteFile(targetJson, body, 0o644)
+	err = os.WriteFile(targetJson, body, 0o644)
 	if err != nil {
 		return err
 	}
@@ -148,7 +148,7 @@ func Activate(sink io.Writer, targetFolder string) error {
 func LoadActivationEnvironment(targetFolder string) []string {
 	result := []string{}
 	targetJson := filepath.Join(targetFolder, activateFile)
-	content, err := ioutil.ReadFile(targetJson)
+	content, err := os.ReadFile(targetJson)
 	if err != nil {
 		return result
 	}

--- a/conda/condayaml.go
+++ b/conda/condayaml.go
@@ -2,7 +2,7 @@ package conda
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -429,13 +429,13 @@ func (it *Environment) SaveAs(filename string) error {
 		return err
 	}
 	common.Trace("FINAL conda environment file as %v:\n---\n%v---", filename, content)
-	return ioutil.WriteFile(filename, []byte(content), 0o640)
+	return os.WriteFile(filename, []byte(content), 0o640)
 }
 
 func (it *Environment) SaveAsRequirements(filename string) error {
 	content := it.AsRequirementsText()
 	common.Trace("FINAL pip requirements as %v:\n---\n%v\n---", filename, content)
-	return ioutil.WriteFile(filename, []byte(content), 0o640)
+	return os.WriteFile(filename, []byte(content), 0o640)
 }
 
 func (it *Environment) AsYaml() (string, error) {
@@ -550,7 +550,7 @@ func CondaYamlFrom(content []byte) (*Environment, error) {
 }
 
 func ReadCondaYaml(filename string) (*Environment, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("%q: %w", filename, err)
 	}

--- a/conda/config.go
+++ b/conda/config.go
@@ -1,7 +1,7 @@
 package conda
 
 import (
-	"io/ioutil"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -20,7 +20,7 @@ func SplitLines(value string) []string {
 }
 
 func ReadConfig(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/conda/workflows.go
+++ b/conda/workflows.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -130,7 +129,7 @@ func newLiveInternal(yaml, condaYaml, requirementsText, key string, force, fresh
 	}
 	defer func() {
 		planSink.Close()
-		content, err := ioutil.ReadFile(planfile)
+		content, err := os.ReadFile(planfile)
 		if err == nil {
 			common.Log("%s", string(content))
 		}
@@ -273,7 +272,7 @@ func newLiveInternal(yaml, condaYaml, requirementsText, key string, force, fresh
 	common.Debug("===  finalize phase ===")
 
 	markerFile := filepath.Join(targetFolder, "identity.yaml")
-	err = ioutil.WriteFile(markerFile, []byte(yaml), 0o644)
+	err = os.WriteFile(markerFile, []byte(yaml), 0o644)
 	if err != nil {
 		return false, false
 	}
@@ -282,7 +281,7 @@ func newLiveInternal(yaml, condaYaml, requirementsText, key string, force, fresh
 	if ok {
 		venvContent := fmt.Sprintf(venvTemplate, targetFolder, pythonVersionAt(targetFolder))
 		venvFile := filepath.Join(targetFolder, "pyvenv.cfg")
-		err = ioutil.WriteFile(venvFile, []byte(venvContent), 0o644)
+		err = os.WriteFile(venvFile, []byte(venvContent), 0o644)
 		if err != nil {
 			return false, false
 		}

--- a/htfs/commands.go
+++ b/htfs/commands.go
@@ -1,7 +1,6 @@
 package htfs
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,7 +134,7 @@ func RecordEnvironment(tree MutableLibrary, blueprint []byte, force bool, scorec
 
 		common.Progress(4, "Build environment into holotree stage.")
 		identityfile := filepath.Join(tree.Stage(), "identity.yaml")
-		err = ioutil.WriteFile(identityfile, blueprint, 0o644)
+		err = os.WriteFile(identityfile, blueprint, 0o644)
 		fail.On(err != nil, "Failed to save %q, reason %w.", identityfile, err)
 		err = conda.LegacyEnvironment(force, identityfile)
 		fail.On(err != nil, "Failed to create environment, reason %w.", err)

--- a/operations/assistant.go
+++ b/operations/assistant.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -202,7 +201,7 @@ func MultipartUpload(url string, fields map[string]string, basename, fullpath st
 }
 
 func IoAsString(source io.Reader) string {
-	body, err := ioutil.ReadAll(source)
+	body, err := io.ReadAll(source)
 	if err != nil {
 		return ""
 	}

--- a/operations/authorize_test.go
+++ b/operations/authorize_test.go
@@ -2,7 +2,7 @@ package operations_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -45,7 +45,7 @@ func TestBodyIsCorrectlyConverted(t *testing.T) {
 
 	reader := strings.NewReader("{\n}")
 	wont_be.Nil(reader)
-	body, err := ioutil.ReadAll(reader)
+	body, err := io.ReadAll(reader)
 	must_be.Nil(err)
 	wont_be.Nil(body)
 	must_be.Equal("{\n}", string(body))

--- a/operations/diagnostics.go
+++ b/operations/diagnostics.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -473,7 +472,7 @@ func diagnoseFilesUnmarshal(tool Unmarshaler, label, rootdir string, paths []str
 		if shouldIgnorePath(fullpath) {
 			continue
 		}
-		content, err := ioutil.ReadFile(fullpath)
+		content, err := os.ReadFile(fullpath)
 		if err != nil {
 			diagnose.Fail(supportGeneralUrl, "Problem reading %s file %q: %v", label, tail, err)
 			success = false

--- a/operations/fixing.go
+++ b/operations/fixing.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,12 +39,12 @@ func ToUnix(content []byte) []byte {
 }
 
 func fixShellFile(fullpath string) {
-	content, err := ioutil.ReadFile(fullpath)
+	content, err := os.ReadFile(fullpath)
 	if err != nil || bytes.IndexByte(content, '\r') < 0 {
 		return
 	}
 	common.Debug("Fixing newlines in file: %v", fullpath)
-	err = ioutil.WriteFile(fullpath, ToUnix(content), 0o755)
+	err = os.WriteFile(fullpath, ToUnix(content), 0o755)
 	if err != nil {
 		common.Log("Failure %v while fixing newlines in %v!", err, fullpath)
 	}

--- a/operations/issues.go
+++ b/operations/issues.go
@@ -3,7 +3,6 @@ package operations
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -19,7 +18,7 @@ const (
 )
 
 func loadToken(reportFile string) (Token, error) {
-	content, err := ioutil.ReadFile(reportFile)
+	content, err := os.ReadFile(reportFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pathlib/walk.go
+++ b/pathlib/walk.go
@@ -1,7 +1,6 @@
 package pathlib
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -93,7 +92,7 @@ func IgnorePattern(text string) Ignore {
 }
 
 func LoadIgnoreFile(filename string) (Ignore, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/robot/robot.go
+++ b/robot/robot.go
@@ -3,7 +3,6 @@ package robot
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -529,7 +528,7 @@ func LoadRobotYaml(filename string, visible bool) (Robot, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%q: %w", filename, err)
 	}
-	content, err := ioutil.ReadFile(fullpath)
+	content, err := os.ReadFile(fullpath)
 	if err != nil {
 		return nil, fmt.Errorf("%q: %w", fullpath, err)
 	}

--- a/robot/setup.go
+++ b/robot/setup.go
@@ -2,7 +2,7 @@ package robot
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/yaml.v2"
@@ -38,7 +38,7 @@ func LoadEnvironmentSetup(filename string) (Setup, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%q: %w", filename, err)
 	}
-	content, err := ioutil.ReadFile(fullpath)
+	content, err := os.ReadFile(fullpath)
 	if err != nil {
 		return nil, fmt.Errorf("%q: %w", fullpath, err)
 	}

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -61,7 +60,7 @@ func CustomSettingsLayer() *Settings {
 }
 
 func LoadSetting(filename string) (*Settings, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir` (`os.ReadDir` returns a slice of `os.DirEntry` rather than a slice of `fs.FileInfo` and it is more efficient [\[1\]])
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

[\[1\]]: https://pkg.go.dev/io/ioutil#ReadDir