### PR TITLE
We need a way to truly disable SSL

### DIFF
--- a/conda/robocorp.go
+++ b/conda/robocorp.go
@@ -111,12 +111,12 @@ func FindPython(location string) (string, bool) {
 func injectNetworkEnvironment(environment []string) []string {
 	if settings.Global.NoRevocation() {
 		environment = append(environment, "MAMBA_SSL_NO_REVOKE=true")
-		environment = append(environment, "RC_NO_SSL_REVOKE=true")
 	}
 	if !settings.Global.VerifySsl() {
 		environment = append(environment, "MAMBA_SSL_VERIFY=false")
 		environment = append(environment, "RC_DISABLE_SSL=true")
 		environment = append(environment, "WDM_SSL_VERIFY=0")
+		environment = append(environment, "NODE_TLS_REJECT_UNAUTHORIZED=0")
 	}
 	environment = appendIfValue(environment, "https_proxy", settings.Global.HttpsProxy())
 	environment = appendIfValue(environment, "HTTPS_PROXY", settings.Global.HttpsProxy())

--- a/conda/robocorp.go
+++ b/conda/robocorp.go
@@ -169,7 +169,6 @@ func CondaExecutionEnvironment(location string, inject []string, full bool) []st
 		environment = appendIfValue(environment, "PIP_CONFIG_FILE", common.PipRcFile())
 	}
 	if settings.Global.HasCaBundle() {
-		environment = appendIfValue(environment, "ROBOCORP_CA_BUNDLE", common.CaBundleFile())
 		environment = appendIfValue(environment, "REQUESTS_CA_BUNDLE", common.CaBundleFile())
 		environment = appendIfValue(environment, "CURL_CA_BUNDLE", common.CaBundleFile())
 		environment = appendIfValue(environment, "SSL_CERT_FILE", common.CaBundleFile())

--- a/conda/robocorp.go
+++ b/conda/robocorp.go
@@ -111,9 +111,11 @@ func FindPython(location string) (string, bool) {
 func injectNetworkEnvironment(environment []string) []string {
 	if settings.Global.NoRevocation() {
 		environment = append(environment, "MAMBA_SSL_NO_REVOKE=true")
+		environment = append(environment, "ROBOCORP_SSL_REVOKE=false")
 	}
 	if !settings.Global.VerifySsl() {
 		environment = append(environment, "MAMBA_SSL_VERIFY=false")
+		environment = append(environment, "ROBOCORP_SSL_VERIFY=false")
 	}
 	environment = appendIfValue(environment, "https_proxy", settings.Global.HttpsProxy())
 	environment = appendIfValue(environment, "HTTPS_PROXY", settings.Global.HttpsProxy())
@@ -166,6 +168,7 @@ func CondaExecutionEnvironment(location string, inject []string, full bool) []st
 		environment = appendIfValue(environment, "PIP_CONFIG_FILE", common.PipRcFile())
 	}
 	if settings.Global.HasCaBundle() {
+		environment = appendIfValue(environment, "ROBOCORP_CA_BUNDLE", common.CaBundleFile())
 		environment = appendIfValue(environment, "REQUESTS_CA_BUNDLE", common.CaBundleFile())
 		environment = appendIfValue(environment, "CURL_CA_BUNDLE", common.CaBundleFile())
 		environment = appendIfValue(environment, "SSL_CERT_FILE", common.CaBundleFile())

--- a/conda/robocorp.go
+++ b/conda/robocorp.go
@@ -111,11 +111,12 @@ func FindPython(location string) (string, bool) {
 func injectNetworkEnvironment(environment []string) []string {
 	if settings.Global.NoRevocation() {
 		environment = append(environment, "MAMBA_SSL_NO_REVOKE=true")
-		environment = append(environment, "ROBOCORP_SSL_REVOKE=false")
+		environment = append(environment, "RC_NO_SSL_REVOKE=true")
 	}
 	if !settings.Global.VerifySsl() {
 		environment = append(environment, "MAMBA_SSL_VERIFY=false")
-		environment = append(environment, "ROBOCORP_SSL_VERIFY=false")
+		environment = append(environment, "RC_DISABLE_SSL=true")
+		environment = append(environment, "WDM_SSL_VERIFY=0")
 	}
 	environment = appendIfValue(environment, "https_proxy", settings.Global.HttpsProxy())
 	environment = appendIfValue(environment, "HTTPS_PROXY", settings.Global.HttpsProxy())


### PR DESCRIPTION
Libraries like requests and urllib3 just do not have sensible env. variable to do this.
> We need to set these in rpaframework and robo libraries
> Rather than binding them to "random" env. variables, set our own.