### PR TITLE
Avoid error upon missing `BUILTIN\Users`

### DIFF
--- a/cmd/command_windows.go
+++ b/cmd/command_windows.go
@@ -18,7 +18,7 @@ func osSpecificHolotreeSharing(enable bool) {
 	parent := filepath.Dir(common.HoloLocation())
 	_, err := pathlib.ForceSharedDir(parent)
 	pretty.Guard(err == nil, 1, "Could not enable shared location at %q, reason: %v", parent, err)
-	task := shell.New(nil, ".", "icacls", "C:/ProgramData/robocorp", "/grant", "BUILTIN\\Users:(OI)(CI)M", "/T", "/Q")
+	task := shell.New(nil, ".", "icacls", "C:/ProgramData/robocorp", "/grant", "*S-1-5-32-545:(OI)(CI)M", "/T", "/Q")
 	_, err = task.Execute(false)
 	pretty.Guard(err == nil, 2, "Could not set 'icacls' settings, reason: %v", err)
 	err = os.WriteFile(common.SharedMarkerLocation(), []byte(common.Version), 0644)

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -420,14 +420,6 @@ The commands to enable the shared locations are:
 * Linux: `sudo rcc holotree shared --enable`
   * Shared location: `/opt/robocorp`
 
-Note: On Windows the command below assumes the standard `BUILTIN\Users`
-user group is present. 
-If your organization has replaced this you can grant the permission with:
-
-```
-icacls "C:\ProgramData\robocorp" /grant "BUILTIN\Users":(OI)(CI)M /T
-```
-
 To switch the user to using shared holotrees use the following command.
 
 ```sh


### PR DESCRIPTION
This commit implements the fix in suggest in https://github.com/robocorp/rcc/issues/54
Since we have proposed the fix, we have tested it with multiple of our customers.