### PR TITLE
docs: fix obsolete data

### DIFF
--- a/conda/platform_windows.go
+++ b/conda/platform_windows.go
@@ -86,7 +86,7 @@ func HasLongPathSupport() bool {
 	code, err := shell.New(nil, ".", "cmd.exe", "/c", "mkdir", fullpath).StderrOnly().Transparent()
 	common.Trace("Checking long path support with MKDIR '%v' (%d characters) -> %v [%v] {%d}", fullpath, len(fullpath), err == nil, err, code)
 	if err != nil {
-		longPathSupportArticle := settings.Global.DocsLink("product-manuals/robocorp-lab/troubleshooting#windows-has-to-have-long-filenames-support-on")
+		longPathSupportArticle := settings.Global.DocsLink("troubleshooting/windows-long-path")
 		common.Log("%sWARNING!  Long path support failed. Reason: %v.%s", pretty.Red, err, pretty.Reset)
 		common.Log("%sWARNING!  See %v for more details.%s", pretty.Red, longPathSupportArticle, pretty.Reset)
 		return false

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -24,7 +24,7 @@ environments and catalogs that your maintenance targets to.
 ## Maintenance vs. tools using holotrees
 
 When doing maintenance on any holotree, you should be aware, that if Robocorp
-tooling (Worker, Assistant, Automation Studio, VS Code plugins, rcc, ...) is
+tooling (Worker, Assistant, VS Code plugins, rcc, ...) is
 also at same time using same holotree/hololib, your maintenance actions might
 have negative effect on those tools.
 


### PR DESCRIPTION
* Fixed link to long paths documentation
* Removed Automation Studio mention
