### PR TITLE
Looking to add a way for the client applications to get the Control Room credential from RCC

### DIFF
--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -36,7 +36,7 @@ var credentialsCmd = &cobra.Command{
 			operations.VerifyAccounts(forceFlag)
 		}
 		if show && !deleteCredentialsFlag {
-			operations.ListAccounts(jsonFlag)
+			operations.ListAccounts(jsonFlag, secretsFlag)
 			return
 		}
 		account = strings.TrimSpace(AccountName())
@@ -86,5 +86,6 @@ func init() {
 	credentialsCmd.Flags().BoolVarP(&defaultFlag, "default", "d", false, "Set this as the default account.")
 	credentialsCmd.Flags().BoolVarP(&jsonFlag, "json", "j", false, "Output in JSON format.")
 	credentialsCmd.Flags().BoolVarP(&verifiedFlag, "verified", "v", false, "Updates the verified timestamp, if the credentials are still active.")
-	credentialsCmd.Flags().StringVarP(&endpointUrl, "endpoint", "e", "", fmt.Sprintf("%s Control Room endpoint used with the given account (or default).", common.Product.Name()))
+	credentialsCmd.Flags().StringVarP(&endpointUrl, "endpoint", "e", "", fmt.Sprintf("%s Control Room endpoint used with the given account (or default).", common.Product.Name))
+	credentialsCmd.Flags().BoolVarP(&secretsFlag, "showSecrets", "", false, "Caution: When used with --json this exposes the credential secret for clients that need them.")
 }

--- a/cmd/sharedvariables.go
+++ b/cmd/sharedvariables.go
@@ -10,6 +10,7 @@ var (
 	dryFlag        bool
 	productionFlag bool
 	verifiedFlag   bool
+	secretsFlag    bool
 )
 
 // options

--- a/common/version.go
+++ b/common/version.go
@@ -1,5 +1,5 @@
 package common
 
 const (
-	Version = `v18.1.6`
+	Version = `v18.1.7`
 )

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # rcc change log
 
+## v18.1.7 (date: 17.9.2024) WORK IN PROGRESS
+
+- Added `--showSecrets` flag that work in conjuction with `rcc configuration credentials --json` to enable applications using RCC to get the Control Room credential
+  - As the help comment says this should be used only when the credentials are actually needed to avoid accidentally logging them etc.  
+
 ## v18.1.6 (date: 21.8.2024)
 
 - unit tests suite now works properly on MacOS and Windows

--- a/operations/credentials.go
+++ b/operations/credentials.go
@@ -185,8 +185,14 @@ func smudgeSecrets(accounts accountList) accountList {
 	return accounts
 }
 
-func ListAccounts(json bool) {
-	accounts := smudgeSecrets(findAccounts())
+func ListAccounts(json bool, secrets bool) {
+	accounts := findAccounts()
+
+	// Smudge secrets by default, unless explicitly requested otherwise
+	if !(json && secrets) {
+		accounts = smudgeSecrets(accounts)
+	}
+
 	if json {
 		listAccountsAsJson(accounts)
 	} else {


### PR DESCRIPTION
- Only in `rcc conf credentials` with both flags `--json` and `--showSecrets` the output JSON will contain the un-smudged secret values
- Making this a very deliberate command, so that user must know they are about to get the secrets that are by default always smudged to avoid accidental logging etc.